### PR TITLE
Removed type casting for some function arguments

### DIFF
--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -43,7 +43,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      * @return object
      * @api
      */
-    public function dispatch(object $event = null, string $eventName = null) : object
+    public function dispatch($event = null, string $eventName = null) : object
     {
         $this->laravelDispatcher->dispatch($event, $eventName);
         $this->symfonyDispatcher->dispatch($event, $eventName);
@@ -109,7 +109,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      *
      * @return array The event listeners for the specified event, or all event listeners by event name
      */
-    public function getListeners(string $eventName = null)
+    public function getListeners($eventName = null)
     {
         return $this->symfonyDispatcher->getListeners($eventName);
     }
@@ -121,7 +121,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      *
      * @return bool true if the specified event has any listeners, false otherwise
      */
-    public function hasListeners(string $eventName = null)
+    public function hasListeners($eventName = null)
     {
         return ($this->symfonyDispatcher->hasListeners($eventName) ||
             $this->laravelDispatcher->hasListeners($eventName));

--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -45,7 +45,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      */
     public function dispatch($event = null, string $eventName = null) : object
     {
-        $this->laravelDispatcher->dispatch($event, $eventName);
+        $this->laravelDispatcher->dispatch($eventName, $event);
         $this->symfonyDispatcher->dispatch($event, $eventName);
 
         return $event;


### PR DESCRIPTION
Resolves the issue where the functions don't align with the Symfony interface.

```
PHP Fatal error:  Declaration of Tmdb\Laravel\Adapters\EventDispatcherAdapter::getListeners(?string $eventName = NULL) must be compatible with Symfony\Component\EventDispatcher\EventDispatcherInterface::getListeners($eventName = NULL) in vendor\dariusiii\tmdb-laravel\src\Adapters\EventDispatcherAdapter.php on line 112
```

It's more of a PHP version error rather than a Laravel specific error - my bad. Currently running PHP 7.4.3.

This is to correct the changes made in the v3.0.1 tag where those function parameters were changed. After removing the types, no additional errors occur. Just need to resolve why the request event isn't triggering.