### PR TITLE
Fix deprecation notice

### DIFF
--- a/src/TmdbServiceProvider.php
+++ b/src/TmdbServiceProvider.php
@@ -41,15 +41,12 @@ class TmdbServiceProvider extends ServiceProvider
 
     /**
      * Construct the TMDB service provider
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
      */
-    public function __construct()
+    public function __construct(Application $app)
     {
-        // Call the parent constructor with all provided arguments
-        $arguments = func_get_args();
-        call_user_func_array(
-            [$this, 'parent::' . __FUNCTION__],
-            $arguments
-        );
+        parent::__construct($app);
 
         $this->registerProvider();
     }


### PR DESCRIPTION
Refactor constructor to accept Application parameter

```php
WARNING: Callables of the form ["Tmdb\Laravel\TmdbServiceProvider", "parent::__construct"] are deprecated in
```